### PR TITLE
Rename gameplay stats field

### DIFF
--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -142,8 +142,8 @@ export function ArcadeHub() {
         setSelectedGameId(gameId);
         setShowHub(false);
         // Track game start
-        userService.updateStats({ 
-          gameplayed: userService.getStats().gameplayed + 1 
+        userService.updateStats({
+          gamesPlayed: userService.getStats().gamesPlayed + 1
         });
         challengeService.updateProgress(gameId, 'games_played', 1);
 

--- a/src/services/UserServices.ts
+++ b/src/services/UserServices.ts
@@ -19,7 +19,7 @@ export interface UserStats {
   powerupsUsed: number;
   achievementsUnlocked: number;
   challengesCompleted: number;
-  gameplayed: number; // total time played in seconds
+  gamesPlayed: number; // total games played
   coinsEarned: number; // total coins earned across all games
 }
 
@@ -60,7 +60,7 @@ export class UserService {
       powerupsUsed: 0,
       achievementsUnlocked: 0,
       challengesCompleted: 0,
-      gameplayed: 0,
+      gamesPlayed: 0,
       coinsEarned: 0
     };
   }
@@ -85,7 +85,13 @@ export class UserService {
     const savedStats = localStorage.getItem('hacktivate-user-stats');
     if (savedStats) {
       try {
-        this.stats = JSON.parse(savedStats);
+        const data = JSON.parse(savedStats);
+        // Migrate old `gameplayed` field to `gamesPlayed`
+        if ('gameplayed' in data && !('gamesPlayed' in data)) {
+          data.gamesPlayed = data.gameplayed;
+          delete data.gameplayed;
+        }
+        this.stats = { ...this.getDefaultStats(), ...data };
       } catch (error) {
         console.warn('Failed to load user stats:', error);
       }


### PR DESCRIPTION
## Summary
- rename `gameplayed` field to `gamesPlayed`
- update ArcadeHub to use new gamesPlayed field
- migrate any older save data on load

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run type-check`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685761c5993c8323b690fd09b0e686a2