### PR TITLE
Add useInput hook and integrate with game module

### DIFF
--- a/src/hooks/useGameModule.ts
+++ b/src/hooks/useGameModule.ts
@@ -1,12 +1,17 @@
 // ===== src/hooks/useGameModule.ts =====
 import { useEffect, useRef, useState } from 'react';
 import { GameModule, Services } from '@/lib/types';
-import { InputManager } from '@/services/InputManager';
+import { useInput } from '@/hooks/useInput';
 import { AudioManager } from '@/services/AudioManager';
 import { Analytics } from '@/services/Analytics';
 import { CurrencyService } from '@/services/CurrencyService';
 
-export function useGameModule(canvas: HTMLCanvasElement | null, game: GameModule | null, currencyService: CurrencyService) {
+export function useGameModule(
+  canvas: HTMLCanvasElement | null,
+  game: GameModule | null,
+  currencyService: CurrencyService
+) {
+  const { input } = useInput(canvas);
   const [isInitialized, setIsInitialized] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const servicesRef = useRef<Services | null>(null);
@@ -17,7 +22,6 @@ export function useGameModule(canvas: HTMLCanvasElement | null, game: GameModule
     if (!canvas || !game) return;
 
     // Initialize services
-    const input = new InputManager();
     const audio = new AudioManager();
     const analytics = new Analytics();
     const currency = currencyService;
@@ -26,7 +30,6 @@ export function useGameModule(canvas: HTMLCanvasElement | null, game: GameModule
     servicesRef.current = services;
 
     // Initialize all services
-    input.init(canvas);
     audio.init();
     analytics.init();
     currency.init();
@@ -36,10 +39,9 @@ export function useGameModule(canvas: HTMLCanvasElement | null, game: GameModule
     setIsInitialized(true);
 
     return () => {
-      input.destroy();
       game.destroy?.();
     };
-  }, [canvas, game, currencyService]);
+  }, [canvas, game, currencyService, input]);
 
   useEffect(() => {
     if (!isInitialized || !game) return;
@@ -48,9 +50,10 @@ export function useGameModule(canvas: HTMLCanvasElement | null, game: GameModule
       const deltaTime = (currentTime - lastTimeRef.current) / 1000;
       lastTimeRef.current = currentTime;
 
-      if (deltaTime < 0.1) { // Cap delta time to prevent large jumps
+      if (deltaTime < 0.1) {
+        // Cap delta time to prevent large jumps
         game.update(deltaTime);
-        
+
         const ctx = canvas?.getContext('2d');
         if (ctx) {
           game.render(ctx);

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,39 @@
+// ===== src/hooks/useInput.ts =====
+import { useEffect, useRef } from 'react';
+import { InputManager } from '@/services/InputManager';
+
+/**
+ * React hook to manage an InputManager instance.
+ *
+ * Basic usage:
+ * ```ts
+ * const { input, isActionPressed } = useInput(canvasRef.current);
+ * ```
+ */
+export function useInput(target: HTMLCanvasElement | Document | null) {
+  const managerRef = useRef<InputManager | null>(null);
+
+  if (!managerRef.current) {
+    managerRef.current = new InputManager();
+  }
+
+  useEffect(() => {
+    const manager = managerRef.current!;
+    if (target) {
+      const canvas =
+        target instanceof HTMLCanvasElement
+          ? target
+          : document.createElement('canvas');
+      manager.init(canvas);
+    }
+    return () => {
+      manager.destroy();
+    };
+  }, [target]);
+
+  return {
+    input: managerRef.current,
+    isActionPressed: () => managerRef.current!.isActionPressed(),
+    getMousePosition: () => managerRef.current!.getMousePosition(),
+  };
+}


### PR DESCRIPTION
## Summary
- implement `useInput` hook to manage `InputManager`
- clean up listeners automatically on unmount
- use `useInput` inside `useGameModule`

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run type-check`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685761e43eb88323b3231eeedc898154