### PR TITLE
Fix lifetime coin tracking

### DIFF
--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -203,13 +203,14 @@ export function ArcadeHub() {
     }
     
     // Update user stats
+    const totalCoinsEarned = stats.coinsEarned + (gameData.coinsEarned || 0);
     const newStats = {
       totalDistance: Math.max(stats.totalDistance, gameData.distance || 0),
       maxSpeed: Math.max(stats.maxSpeed, gameData.speed || 0),
       maxCombo: Math.max(stats.maxCombo, gameData.combo || 0),
       totalJumps: stats.totalJumps + (gameData.jumps || 0),
       powerupsUsed: stats.powerupsUsed + (gameData.powerupsUsed || 0),
-      coinsEarned: stats.coinsEarned + (gameData.coinsEarned || 0)
+      coinsEarned: totalCoinsEarned
     };
     userService.updateStats(newStats);
     const updatedStats = userService.getStats();
@@ -243,7 +244,7 @@ export function ArcadeHub() {
         'total_playtime',
         profile.totalPlayTime + playTimeSeconds
       ),
-      ...achievementService.checkAchievement('total_coins_earned', updatedStats.coinsEarned),
+      ...achievementService.checkAchievement('total_coins_earned', totalCoinsEarned),
       ...achievementService.checkAchievement('jumps', gameData.jumps || 0, selectedGameId),
       ...achievementService.checkAchievement('total_jumps', updatedStats.totalJumps),
       ...achievementService.checkAchievement('powerups_total', updatedStats.powerupsUsed),


### PR DESCRIPTION
## Summary
- compute total coins earned using saved stats at game end
- trigger Rich Player check with lifetime coins

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6858787cbae48323a92891567da0dc0b