### PR TITLE
Handle placeholder dates in user profile

### DIFF
--- a/src/components/arcade/UserProfiles.tsx
+++ b/src/components/arcade/UserProfiles.tsx
@@ -114,11 +114,15 @@ export function UserProfile({ userService }: UserProfileProps) {
 
       {/* Member since */}
       <div className="mt-4 text-xs text-gray-400 text-center">
-        Member since {profile.joinedAt.toLocaleDateString()}
+        {profile.joinedAt.getTime() === 0
+          ? 'Member since N/A'
+          : `Member since ${profile.joinedAt.toLocaleDateString()}`}
       </div>
       {/* Last active */}
       <div className="text-xs text-gray-400 text-center">
-        Last active {profile.lastActiveAt.toLocaleDateString()} at {profile.lastActiveAt.toLocaleTimeString()}    
+        {profile.lastActiveAt.getTime() === 0
+          ? 'Last active N/A'
+          : `Last active ${profile.lastActiveAt.toLocaleDateString()} at ${profile.lastActiveAt.toLocaleTimeString()}`}
       </div>
     </div>
   );

--- a/src/services/UserServices.ts
+++ b/src/services/UserServices.ts
@@ -35,9 +35,21 @@ export class UserService {
 
   init(): void {
     this.loadUserData();
+
+    if (typeof window !== 'undefined') {
+      const savedProfile = localStorage.getItem('hacktivate-user-profile');
+      if (!savedProfile) {
+        this.profile.joinedAt = new Date();
+        this.profile.lastActiveAt = new Date();
+        this.saveUserData();
+      }
+    }
   }
 
   private getDefaultProfile(): UserProfile {
+    const placeholderDate = new Date(0);
+    const currentDate = new Date();
+    const date = typeof window === 'undefined' ? placeholderDate : currentDate;
     return {
       username: 'Player',
       level: 1,
@@ -46,8 +58,8 @@ export class UserService {
       totalCoins: 0,
       totalPlayTime: 0,
       gamesPlayed: 0,
-      joinedAt: new Date(),
-      lastActiveAt: new Date()
+      joinedAt: date,
+      lastActiveAt: date
     };
   }
 


### PR DESCRIPTION
## Summary
- use `new Date(0)` as placeholder for profile dates when on server
- set real timestamps on init when no user profile is stored
- display `N/A` when placeholder dates are used

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68587f13ac888323ae1743e2dc051bc0