### PR TITLE
Adjust level progression curve

### DIFF
--- a/src/components/arcade/UserProfiles.tsx
+++ b/src/components/arcade/UserProfiles.tsx
@@ -27,8 +27,11 @@ export function UserProfile({ userService }: UserProfileProps) {
     setMounted(true);
   }, []);
 
-  const experienceToNextLevel = 1000 - (profile.experience % 1000);
-  const experienceProgress = (profile.experience % 1000) / 1000;
+  const currentLevelXp = UserService.experienceForLevel(profile.level);
+  const nextLevelXp = UserService.experienceForLevel(profile.level + 1);
+  const experienceToNextLevel = nextLevelXp - profile.experience;
+  const experienceProgress =
+    (profile.experience - currentLevelXp) / (nextLevelXp - currentLevelXp);
 
   const handleAvatarChange = (newAvatar: string) => {
     userService.updateProfile({ avatar: newAvatar });

--- a/src/services/UserServices.ts
+++ b/src/services/UserServices.ts
@@ -128,12 +128,18 @@ export class UserService {
     this.notifyListeners();
   }
 
+  public static experienceForLevel(level: number): number {
+    return 500 * level * (level - 1);
+  }
+
   addExperience(amount: number): { leveledUp: boolean; newLevel: number } {
     const oldLevel = this.profile.level;
     this.profile.experience += amount;
-    
-    // Calculate level based on experience
-    const newLevel = Math.floor(this.profile.experience / 1000) + 1;
+
+    // Calculate level based on experience using quadratic scaling
+    const newLevel = Math.floor(
+      (1 + Math.sqrt(1 + (4 * this.profile.experience) / 500)) / 2
+    );
     const leveledUp = newLevel > oldLevel;
     
     if (leveledUp) {


### PR DESCRIPTION
## Summary
- rework UserService level calculation for slower level-ups
- compute dynamic XP requirements in profile display

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6858b9d598688323830d73c40e3c7f3d