### PR TITLE
Integrate puzzle game and achievements

### DIFF
--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -255,6 +255,8 @@ export function ArcadeHub() {
             selectedGameId
           )
         : []),
+      ...achievementService.checkAchievement('lines_cleared', gameData.linesCleared || 0, selectedGameId),
+      ...achievementService.checkAchievement('puzzle_level', gameData.level || 0, selectedGameId),
       ...achievementService.checkAchievement('games_played', updatedStats.gamesPlayed)
     ];
 

--- a/src/games/block/index.ts
+++ b/src/games/block/index.ts
@@ -1,1 +1,1 @@
-export { BlockPuzzleGame } from './blockPuzzleGame';
+export { BlockPuzzleGame } from './BlockPuzzleGame';

--- a/src/services/AchievementService.ts
+++ b/src/services/AchievementService.ts
@@ -203,6 +203,39 @@ export class AchievementService {
         requirement: { type: 'total_coins_earned', value: 50000 },
         reward: 2000,
         unlocked: false
+      },
+      {
+        id: 'puzzle_rookie',
+        title: 'Puzzle Rookie',
+        description: 'Clear 10 lines in Block Puzzle',
+        icon: '🧱',
+        gameId: 'puzzle',
+        category: 'gameplay',
+        requirement: { type: 'lines_cleared', value: 10 },
+        reward: 50,
+        unlocked: false
+      },
+      {
+        id: 'puzzle_veteran',
+        title: 'Puzzle Veteran',
+        description: 'Clear 100 lines in Block Puzzle',
+        icon: '🏗️',
+        gameId: 'puzzle',
+        category: 'skill',
+        requirement: { type: 'lines_cleared', value: 100 },
+        reward: 200,
+        unlocked: false
+      },
+      {
+        id: 'puzzle_master',
+        title: 'Puzzle Master',
+        description: 'Reach level 10 in Block Puzzle',
+        icon: '🧩',
+        gameId: 'puzzle',
+        category: 'skill',
+        requirement: { type: 'puzzle_level', value: 10 },
+        reward: 300,
+        unlocked: false
       }
     ];
   }


### PR DESCRIPTION
## Summary
- fix export path for BlockPuzzleGame
- hook puzzle achievements into ArcadeHub
- add several puzzle-specific achievements

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run type-check` *(fails: type errors in existing code)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858da003f908323a7b5588f30178cd9