### PR TITLE
Adjust speed achievements thresholds

### DIFF
--- a/DOCS/ArcadeHubEnhancement.md
+++ b/DOCS/ArcadeHubEnhancement.md
@@ -147,7 +147,7 @@ npm run dev
 ### **Achievement Examples:**
 - 🦅 **"Taking Flight"** - Jump for the first time (50 coins)
 - 💰 **"Coin Collector"** - Collect 100 coins total (100 coins)
-- ⚡ **"Speed Demon"** - Reach 3x speed (200 coins)
+- ⚡ **"Speed Demon"** - Reach 2x speed (200 coins)
 - 🏃‍♂️ **"Marathon Runner"** - Run 5000 meters (300 coins)
 - 🏆 **"Completionist"** - Unlock all games (500 coins)
 

--- a/src/services/AchievementService.ts
+++ b/src/services/AchievementService.ts
@@ -51,10 +51,10 @@ export class AchievementService {
       {
         id: 'speed_demon',
         title: 'Speed Demon',
-        description: 'Reach 3x speed',
+        description: 'Reach 2x speed',
         icon: '⚡',
         category: 'skill',
-        requirement: { type: 'max_speed', value: 3 },
+        requirement: { type: 'max_speed', value: 2 },
         reward: 200,
         unlocked: false
       },
@@ -177,10 +177,10 @@ export class AchievementService {
       {
         id: 'speed_freak',
         title: 'Speed Freak',
-        description: 'Reach 5x speed',
+        description: 'Reach 3.5x speed',
         icon: '💨',
         category: 'skill',
-        requirement: { type: 'max_speed', value: 5 },
+        requirement: { type: 'max_speed', value: 3.5 },
         reward: 300,
         unlocked: false
       },


### PR DESCRIPTION
## Summary
- lower Speed Demon requirement from 3x to 2x speed
- lower Speed Freak requirement from 5x to 3.5x speed
- update docs to reflect new Speed Demon threshold

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other issues)*
- `npm run type-check`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a5a9f00083239c52c104381f92ba