### PR TITLE
Expand Block Puzzle achievements

### DIFF
--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -257,6 +257,9 @@ export function ArcadeHub() {
         : []),
       ...achievementService.checkAchievement('lines_cleared', gameData.linesCleared || 0, selectedGameId),
       ...achievementService.checkAchievement('puzzle_level', gameData.level || 0, selectedGameId),
+      ...achievementService.checkAchievement('score', gameData.score || 0, selectedGameId),
+      ...achievementService.checkAchievement('tetris_count', gameData.tetrisCount || 0, selectedGameId),
+      ...achievementService.checkAchievement('unique_themes', gameData.uniqueThemes || 0, selectedGameId),
       ...achievementService.checkAchievement('games_played', updatedStats.gamesPlayed)
     ];
 

--- a/src/services/AchievementService.ts
+++ b/src/services/AchievementService.ts
@@ -236,6 +236,72 @@ export class AchievementService {
         requirement: { type: 'puzzle_level', value: 10 },
         reward: 300,
         unlocked: false
+      },
+      {
+        id: 'puzzle_score_beginner',
+        title: 'Puzzle Scorer',
+        description: 'Score 1,000 points in Block Puzzle',
+        icon: '🔢',
+        gameId: 'puzzle',
+        category: 'skill',
+        requirement: { type: 'score', value: 1000 },
+        reward: 100,
+        unlocked: false
+      },
+      {
+        id: 'puzzle_score_pro',
+        title: 'Puzzle Pro',
+        description: 'Score 5,000 points in Block Puzzle',
+        icon: '🧠',
+        gameId: 'puzzle',
+        category: 'skill',
+        requirement: { type: 'score', value: 5000 },
+        reward: 250,
+        unlocked: false
+      },
+      {
+        id: 'puzzle_tetris',
+        title: 'Tetris!',
+        description: 'Clear a Tetris in Block Puzzle',
+        icon: '🎯',
+        gameId: 'puzzle',
+        category: 'gameplay',
+        requirement: { type: 'tetris_count', value: 1 },
+        reward: 150,
+        unlocked: false
+      },
+      {
+        id: 'puzzle_tetris_king',
+        title: 'Tetris King',
+        description: 'Clear 10 Tetrises in Block Puzzle',
+        icon: '👑',
+        gameId: 'puzzle',
+        category: 'skill',
+        requirement: { type: 'tetris_count', value: 10 },
+        reward: 400,
+        unlocked: false
+      },
+      {
+        id: 'puzzle_theme_explorer',
+        title: 'Theme Explorer',
+        description: 'Experience 3 different themes',
+        icon: '🎨',
+        gameId: 'puzzle',
+        category: 'gameplay',
+        requirement: { type: 'unique_themes', value: 3 },
+        reward: 100,
+        unlocked: false
+      },
+      {
+        id: 'puzzle_theme_master',
+        title: 'Theme Connoisseur',
+        description: 'Experience all themes in Block Puzzle',
+        icon: '🏅',
+        gameId: 'puzzle',
+        category: 'skill',
+        requirement: { type: 'unique_themes', value: 5 },
+        reward: 300,
+        unlocked: false
       }
     ];
   }


### PR DESCRIPTION
## Summary
- track tetris clears and themes encountered
- expose new stats to the arcade hub
- add score/tetris/theme achievements for Block Puzzle
- check these achievements when a puzzle game ends

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6859b0d3b82c832399a71113a75fc726