### PR TITLE
Improve game carousel layout

### DIFF
--- a/public/games/asteroids/asteroids-thumb.svg
+++ b/public/games/asteroids/asteroids-thumb.svg
@@ -1,0 +1,9 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" fill="#0F172A"/>
+  <circle cx="256" cy="256" r="80" fill="#64748B"/>
+  <circle cx="220" cy="230" r="12" fill="#475569"/>
+  <circle cx="290" cy="270" r="16" fill="#475569"/>
+  <rect x="0" y="420" width="512" height="92" fill="rgba(0,0,0,0.9)"/>
+  <text x="256" y="455" text-anchor="middle" font-size="24" font-weight="bold" fill="#06B6D4">ASTEROIDS</text>
+  <text x="256" y="485" text-anchor="middle" font-size="18" font-weight="bold" fill="#94A3B8">COMING SOON</text>
+</svg>

--- a/public/games/snake/snake-thumb.svg
+++ b/public/games/snake/snake-thumb.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" fill="#051B11"/>
+  <path d="M100 260 h80 v-40 h80 v80 h80 v40 h80" stroke="#34D399" stroke-width="20" fill="none" stroke-linecap="round"/>
+  <circle cx="420" cy="340" r="12" fill="#F59E0B"/>
+  <rect x="0" y="420" width="512" height="92" fill="rgba(0,0,0,0.9)"/>
+  <text x="256" y="455" text-anchor="middle" font-size="24" font-weight="bold" fill="#34D399">SNAKE</text>
+  <text x="256" y="485" text-anchor="middle" font-size="18" font-weight="bold" fill="#94A3B8">COMING SOON</text>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,3 +91,18 @@ body {
   background-size: 200px 100%;
   animation: shimmer 1.5s infinite;
 }
+
+/* Custom scrollbar styling */
+.custom-scrollbar {
+  scrollbar-color: #8B5CF6 #1F2937; /* thumb color track color */
+}
+.custom-scrollbar::-webkit-scrollbar {
+  height: 8px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: #1F2937;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #8B5CF6;
+  border-radius: 4px;
+}

--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -25,24 +25,41 @@ const AVAILABLE_GAMES: GameManifest[] = [
     tier: 0,
     description: 'Jump and collect coins in this fast-paced endless runner!'
   },
-  // Placeholder for future games
   {
-    id: 'puzzle',
-    title: 'Block Puzzle',
-    thumbnail: '/games/puzzle/puzzle-thumb.svg',
-    inputSchema: ['keyboard', 'touch'],
+    id: "puzzle",
+    title: "Block Puzzle",
+    thumbnail: "/games/puzzle/puzzle-thumb.svg",
+    inputSchema: ["keyboard", "touch"],
     assetBudgetKB: 75,
     tier: 1,
-    description: 'Match blocks to clear lines.'
+    description: "Match blocks to clear lines."
   },
   {
-    id: 'space',
-    title: 'Space Shooter',
-    thumbnail: '/games/space/space-thumb.svg',
-    inputSchema: ['keyboard'],
+    id: "snake",
+    title: "Snake",
+    thumbnail: "/games/snake/snake-thumb.svg",
+    inputSchema: ["keyboard", "touch"],
+    assetBudgetKB: 60,
+    tier: 1,
+    description: "Classic snake action. Coming soon!"
+  },
+  {
+    id: "space",
+    title: "Space Shooter",
+    thumbnail: "/games/space/space-thumb.svg",
+    inputSchema: ["keyboard"],
     assetBudgetKB: 100,
     tier: 2,
-    description: 'Coming Soon! Defend Earth from alien invaders!'
+    description: "Coming Soon! Defend Earth from alien invaders!"
+  },
+  {
+    id: "asteroids",
+    title: "Asteroids",
+    thumbnail: "/games/asteroids/asteroids-thumb.svg",
+    inputSchema: ["keyboard"],
+    assetBudgetKB: 120,
+    tier: 2,
+    description: "Blast space rocks in this retro shooter. Coming soon!"
   }
 ];
 

--- a/src/components/arcade/GameCarousel.tsx
+++ b/src/components/arcade/GameCarousel.tsx
@@ -16,7 +16,7 @@ interface GameCarouselProps {
 }
 
 export function GameCarousel({ games, unlockedTiers, currentCoins, onGameSelect, onGameUnlock }: GameCarouselProps) {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedGameId, setSelectedGameId] = useState<string>(games[0]?.id || '');
   const [imageErrors, setImageErrors] = useState<Set<string>>(new Set());
 
 
@@ -59,7 +59,7 @@ export function GameCarousel({ games, unlockedTiers, currentCoins, onGameSelect,
             unlocked ? 'opacity-100' : 'opacity-50 grayscale'
           }`}
           onError={() => handleImageError(game.id)}
-          priority={selectedIndex === 0} // Prioritize first image
+          priority={game.id === games[0]?.id}
         />
         {!unlocked && (
           <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
@@ -71,26 +71,31 @@ export function GameCarousel({ games, unlockedTiers, currentCoins, onGameSelect,
   };
 
 
-  return (
-    <div className="w-full">
-      <h2 className="text-2xl font-bold text-white mb-6 text-center">Game Arcade</h2>
-      
-      <div className="flex gap-4 overflow-x-auto pb-4">
-        {games.map((game, index) => {
-          const unlocked = isGameUnlocked(game);
-          const canUnlock = canUnlockGame(game);
-          const cost = getUnlockCost(game);
+  const tiers = Array.from(new Set(games.map(g => g.tier))).sort((a, b) => a - b);
 
-          return (
-            <div
-              key={game.id}
-              className={`game-card min-w-[200px] ${
-                selectedIndex === index ? 'ring-2 ring-primary-400' : ''
-              }`}
-              onClick={() => setSelectedIndex(index)}
-            >
-              <div className="aspect-square bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center relative">
-                {renderThumbnail(game, unlocked)}
+  return (
+    <div className="w-full space-y-8">
+      <h2 className="text-2xl font-bold text-white mb-6 text-center">Game Arcade</h2>
+
+      {tiers.map(tier => (
+        <div key={tier} className="space-y-4">
+          <h3 className="text-lg font-semibold text-white">Tier {tier}</h3>
+          <div className="flex gap-4 overflow-x-auto pb-4 custom-scrollbar">
+            {games.filter(g => g.tier === tier).map((game) => {
+              const unlocked = isGameUnlocked(game);
+              const canUnlock = canUnlockGame(game);
+              const cost = getUnlockCost(game);
+
+              return (
+                <div
+                  key={game.id}
+                  className={`game-card w-64 flex-shrink-0 ${
+                    selectedGameId === game.id ? 'ring-2 ring-primary-400' : ''
+                  }`}
+                  onClick={() => setSelectedGameId(game.id)}
+                >
+                  <div className="aspect-square bg-gradient-to-br from-gray-700 to-gray-800 flex items-center justify-center relative">
+                    {renderThumbnail(game, unlocked)}
                 {/* {unlocked ? (
                   <div className="text-4xl">🎮</div>
                 ) : (
@@ -102,42 +107,44 @@ export function GameCarousel({ games, unlockedTiers, currentCoins, onGameSelect,
                     {cost} coins
                   </div>
                 )}
-              </div>
-              
-              <div className="p-4">
-                <h3 className="font-bold text-white mb-2">{game.title}</h3>
-                <p className="text-sm text-gray-300 mb-3">{game.description}</p>
-                
-                {unlocked ? (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onGameSelect(game.id);
-                    }}
-                    className="w-full arcade-button text-sm py-2"
-                  >
-                    Play Game
-                  </button>
-                ) : canUnlock ? (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onGameUnlock(game.id, cost);
-                    }}
-                    className="w-full bg-yellow-500 hover:bg-yellow-600 text-black font-bold py-2 px-4 rounded-lg transition-colors text-sm"
-                  >
-                    Unlock for {cost} coins
-                  </button>
-                ) : (
-                  <div className="w-full bg-gray-600 text-gray-400 font-bold py-2 px-4 rounded-lg text-center text-sm">
-                    Need {cost} coins
                   </div>
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </div>
+
+                  <div className="p-4">
+                    <h3 className="font-bold text-white mb-2">{game.title}</h3>
+                    <p className="text-sm text-gray-300 mb-3">{game.description}</p>
+
+                    {unlocked ? (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onGameSelect(game.id);
+                        }}
+                        className="w-full arcade-button text-sm py-2"
+                      >
+                        Play Game
+                      </button>
+                    ) : canUnlock ? (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onGameUnlock(game.id, cost);
+                        }}
+                        className="w-full bg-yellow-500 hover:bg-yellow-600 text-black font-bold py-2 px-4 rounded-lg transition-colors text-sm"
+                      >
+                        Unlock for {cost} coins
+                      </button>
+                    ) : (
+                      <div className="w-full bg-gray-600 text-gray-400 font-bold py-2 px-4 rounded-lg text-center text-sm">
+                        Need {cost} coins
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- group games into tier rows and fix card sizing
- customize scrollbar style to match theme
- add Snake (tier 1) and Asteroids (tier 2) placeholders

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ea5685848323abecc0ad46bcacbb