### PR TITLE
Add combo and timer to Block Puzzle

### DIFF
--- a/src/games/block/systems/ComboSystem.ts
+++ b/src/games/block/systems/ComboSystem.ts
@@ -1,0 +1,52 @@
+export class ComboSystem {
+  private combo = 0;
+  private timer = 0;
+  private timeLimit = 3; // seconds to continue combo
+  private multiplier = 1;
+
+  addClear(lines: number): number {
+    if (lines > 0) {
+      this.combo += 1;
+      this.timer = this.timeLimit;
+
+      // simple multiplier scaling
+      if (this.combo >= 4) {
+        this.multiplier = 3;
+      } else if (this.combo >= 2) {
+        this.multiplier = 2;
+      } else {
+        this.multiplier = 1;
+      }
+    } else {
+      this.reset();
+    }
+    return this.multiplier;
+  }
+
+  update(dt: number): void {
+    if (this.timer > 0) {
+      this.timer -= dt;
+      if (this.timer <= 0) {
+        this.reset();
+      }
+    }
+  }
+
+  reset(): void {
+    this.combo = 0;
+    this.timer = 0;
+    this.multiplier = 1;
+  }
+
+  getCombo(): number {
+    return this.combo;
+  }
+
+  getMultiplier(): number {
+    return this.multiplier;
+  }
+
+  getTimeLeft(): number {
+    return this.timer;
+  }
+}

--- a/src/games/block/systems/EnvironmentSystem.ts
+++ b/src/games/block/systems/EnvironmentSystem.ts
@@ -93,8 +93,40 @@ export class EnvironmentSystem {
           yellow: '#ffa502',
           purple: '#a55eea',
           orange: '#ff6348',
-          cyan: '#26d0ce',
-        };
+        cyan: '#26d0ce',
+      };
     }
+  }
+
+  drawBackground(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number
+  ): void {
+    const gradient = ctx.createLinearGradient(0, 0, 0, height);
+    switch (this.currentTheme) {
+      case 'neon':
+        gradient.addColorStop(0, '#141414');
+        gradient.addColorStop(1, '#000000');
+        break;
+      case 'ice':
+        gradient.addColorStop(0, '#e0f7fa');
+        gradient.addColorStop(1, '#b3e5fc');
+        break;
+      case 'retro':
+        gradient.addColorStop(0, '#3a3a3a');
+        gradient.addColorStop(1, '#2d2d2d');
+        break;
+      case 'dusk':
+        gradient.addColorStop(0, '#1e293b');
+        gradient.addColorStop(1, '#0f172a');
+        break;
+      default:
+        gradient.addColorStop(0, '#1a1a2e');
+        gradient.addColorStop(1, '#111111');
+        break;
+    }
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, width, height);
   }
 }


### PR DESCRIPTION
## Summary
- add a combo system for Block Puzzle line clears
- implement a timed challenge mode
- show remaining time and combo in the UI
- polish ghost piece appearance with shadow
- draw theme-specific gradient backgrounds

## Testing
- `npm run lint` *(fails: React/TS lint errors)*
- `npm run type-check`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a15f114a08323b597e9274cb1c8df