### PR TITLE
Add hover enemy & updated spawn logic

### DIFF
--- a/src/games/runner/RunnerGame.ts
+++ b/src/games/runner/RunnerGame.ts
@@ -6,6 +6,7 @@ import { Obstacle } from './entities/Obstacle';
 import { Coin } from './entities/Coin';
 import { PowerUp, PowerUpType } from './entities/PowerUp';
 import { FlyingEnemy } from './entities/FlyingEnemy';
+import { HoverEnemy } from './entities/HoverEnemy';
 import { ParticleSystem } from './systems/ParticleSystem';
 import { ScreenShake } from './systems/ScreenShake';
 import { ComboSystem } from './systems/ComboSystem';
@@ -33,14 +34,17 @@ export class RunnerGame extends BaseGame {
   private coins: Coin[] = [];
   private powerUps: PowerUp[] = [];
   private flyingEnemies: FlyingEnemy[] = [];
+  private hoverEnemies: HoverEnemy[] = [];
   private particles!: ParticleSystem;
   private screenShake!: ScreenShake;
   private comboSystem!: ComboSystem;
   private environmentSystem!: EnvironmentSystem;
   
   private gameSpeed: number = 1;
-  private spawnTimer: number = 0;
-  private spawnInterval: number = 2;
+  private obstacleSpawnTimer: number = 0;
+  private obstacleSpawnInterval: number = 1.5;
+  private aerialSpawnTimer: number = 0;
+  private aerialSpawnInterval: number = 2.5;
   private distance: number = 0;
   private groundY: number = 0;
   private jumps: number = 0;
@@ -182,6 +186,10 @@ export class RunnerGame extends BaseGame {
     // Update flying enemies
     this.flyingEnemies.forEach(enemy => enemy.update(dt, gameSpeed));
     this.flyingEnemies = this.flyingEnemies.filter(enemy => !enemy.isOffScreen());
+
+    // Update hover enemies
+    this.hoverEnemies.forEach(enemy => enemy.update(dt, gameSpeed));
+    this.hoverEnemies = this.hoverEnemies.filter(enemy => !enemy.isOffScreen());
   }
 
   private updateSystems(dt: number): void {
@@ -200,33 +208,41 @@ export class RunnerGame extends BaseGame {
   }
 
   private handleSpawning(): void {
-    this.spawnTimer += this.gameSpeed * 0.016; // Approximate dt
-    
-    if (this.spawnTimer >= this.spawnInterval) {
-      this.spawnTimer = 0;
-      
-      // Spawn obstacles
-      if (Math.random() < 0.6) {
+    const dt = this.gameSpeed * 0.016; // Approximate frame time scaled by speed
+
+    this.obstacleSpawnTimer += dt;
+    this.aerialSpawnTimer += dt;
+
+    if (this.obstacleSpawnTimer >= this.obstacleSpawnInterval) {
+      this.obstacleSpawnTimer = 0;
+
+      if (Math.random() < 0.8) {
         this.spawnObstacle();
       }
-      
-      // Spawn flying enemies (less frequent)
-      if (Math.random() < 0.2 && this.distance > 500) {
-        this.spawnFlyingEnemy();
-      }
-      
-      // Spawn coins
-      if (Math.random() < 0.7) {
+
+      if (Math.random() < 0.6) {
         this.spawnCoin();
       }
-      
-      // Spawn power-ups (rare)
+
       if (Math.random() < 0.15 && this.distance > 300) {
         this.spawnPowerUp();
       }
-      
-      // Adjust spawn rate
-      this.spawnInterval = Math.max(0.8, 2 - (this.gameSpeed - 1) * 0.2);
+
+      this.obstacleSpawnInterval = Math.max(0.8, 1.5 - (this.gameSpeed - 1) * 0.1);
+    }
+
+    if (this.aerialSpawnTimer >= this.aerialSpawnInterval) {
+      this.aerialSpawnTimer = 0;
+
+      if (Math.random() < 0.5 && this.distance > 500) {
+        this.spawnFlyingEnemy();
+      }
+
+      if (Math.random() < 0.4 && this.distance > 800) {
+        this.spawnHoverEnemy();
+      }
+
+      this.aerialSpawnInterval = Math.max(1.2, 2.5 - (this.gameSpeed - 1) * 0.1);
     }
   }
 
@@ -242,6 +258,7 @@ export class RunnerGame extends BaseGame {
     // Render all entities
     this.obstacles.forEach(obstacle => obstacle.render(ctx));
     this.flyingEnemies.forEach(enemy => enemy.render(ctx));
+    this.hoverEnemies.forEach(enemy => enemy.render(ctx));
     this.coins.forEach(coin => coin.render(ctx));
     this.powerUps.forEach(powerUp => powerUp.render(ctx));
     
@@ -393,6 +410,12 @@ export class RunnerGame extends BaseGame {
     this.flyingEnemies.push(new FlyingEnemy(x, y));
   }
 
+  private spawnHoverEnemy(): void {
+    const x = this.canvas.width + 50;
+    const y = this.groundY - 80;
+    this.hoverEnemies.push(new HoverEnemy(x, y));
+  }
+
   private spawnObstacle(): void {
     const x = this.canvas.width + 50;
     const y = this.groundY - 48;
@@ -422,6 +445,16 @@ export class RunnerGame extends BaseGame {
       
       // Check flying enemy collisions
       for (const enemy of this.flyingEnemies) {
+        if (playerBounds.intersects(enemy.getBounds())) {
+          this.services.audio.playSound('collision');
+          this.screenShake.shake(8, 0.25);
+          this.endGame();
+          return;
+        }
+      }
+
+      // Check hover enemy collisions
+      for (const enemy of this.hoverEnemies) {
         if (playerBounds.intersects(enemy.getBounds())) {
           this.services.audio.playSound('collision');
           this.screenShake.shake(8, 0.25);
@@ -526,14 +559,17 @@ export class RunnerGame extends BaseGame {
     this.coins = [];
     this.powerUps = [];
     this.flyingEnemies = [];
+    this.hoverEnemies = [];
     this.activePowerUps = [];
     this.particles = new ParticleSystem();
     this.screenShake = new ScreenShake();
     this.comboSystem = new ComboSystem();
     this.environmentSystem = new EnvironmentSystem();
     this.gameSpeed = 1;
-    this.spawnTimer = 0;
-    this.spawnInterval = 2;
+    this.obstacleSpawnTimer = 0;
+    this.obstacleSpawnInterval = 1.5;
+    this.aerialSpawnTimer = 0;
+    this.aerialSpawnInterval = 2.5;
     this.distance = 0;
     this.jumps = 0;
     this.powerupsUsed = 0;

--- a/src/games/runner/entities/HoverEnemy.ts
+++ b/src/games/runner/entities/HoverEnemy.ts
@@ -1,0 +1,51 @@
+import { Vector2, Rectangle } from '@/games/shared/utils/Vector2';
+
+export class HoverEnemy {
+  position: Vector2;
+  velocity: Vector2;
+  size: Vector2;
+
+  private bobOffset = 0;
+  private bobSpeed = 3;
+
+  constructor(x: number, y: number) {
+    this.position = new Vector2(x, y);
+    this.velocity = new Vector2(-180, 0);
+    this.size = new Vector2(32, 24);
+  }
+
+  update(dt: number, gameSpeed: number): void {
+    this.velocity.x = -180 * gameSpeed;
+    this.position = this.position.add(this.velocity.multiply(dt));
+
+    this.bobOffset = Math.sin((Date.now() / 1000) * this.bobSpeed) * 5;
+  }
+
+  render(ctx: CanvasRenderingContext2D): void {
+    const renderY = this.position.y + this.bobOffset;
+    ctx.save();
+    ctx.translate(this.position.x + this.size.x / 2, renderY + this.size.y / 2);
+
+    ctx.fillStyle = '#4B5563';
+    ctx.fillRect(-this.size.x / 2, -this.size.y / 2, this.size.x, this.size.y);
+
+    ctx.fillStyle = '#F87171';
+    ctx.fillRect(6 - this.size.x / 2, -2, 4, 4);
+    ctx.fillRect(this.size.x / 2 - 10, -2, 4, 4);
+
+    ctx.restore();
+  }
+
+  getBounds(): Rectangle {
+    return new Rectangle(
+      this.position.x,
+      this.position.y + this.bobOffset,
+      this.size.x,
+      this.size.y,
+    );
+  }
+
+  isOffScreen(): boolean {
+    return this.position.x + this.size.x < 0;
+  }
+}

--- a/src/games/runner/entities/Player.ts
+++ b/src/games/runner/entities/Player.ts
@@ -13,6 +13,9 @@ export class Player {
   private jumpsRemaining: number = 1;
   private maxJumps: number = 1;
   private lastJumpPressed: boolean = false;
+  private isJumping: boolean = false;
+  private jumpHoldTime: number = 0;
+  private maxJumpHold: number = 0.25;
 
   // Animation
   private frameTime: number = 0;
@@ -40,6 +43,16 @@ export class Player {
     if (inputPressed && !this.lastJumpPressed && this.jumpsRemaining > 0) {
       this.jump();
     }
+
+    if (inputPressed && this.isJumping && this.jumpHoldTime < this.maxJumpHold) {
+      this.velocity.y += this.jumpPower * 0.02;
+      this.jumpHoldTime += dt;
+    }
+
+    if (!inputPressed) {
+      this.isJumping = false;
+    }
+
     this.lastJumpPressed = inputPressed;
 
     // Apply gravity
@@ -54,6 +67,7 @@ export class Player {
       this.position.y = this.groundY - this.size.y;
       this.velocity.y = 0;
       this.isGrounded = true;
+      this.isJumping = false;
       this.jumpsRemaining = this.maxJumps;
       
       // Squash effect on landing (only if we were in the air)
@@ -102,6 +116,8 @@ export class Player {
     if (this.jumpsRemaining > 0) {
       this.velocity.y = this.jumpPower;
       this.jumpsRemaining--;
+      this.isJumping = true;
+      this.jumpHoldTime = 0;
       
       // Stretch effect on jump
       this.squashStretch = 0.6; // More pronounced stretch


### PR DESCRIPTION
## Summary
- add `HoverEnemy` entity for mid-air threats
- implement separate obstacle and aerial spawn timers
- spawn new hover enemies and render/collide with them
- improve player jump with variable jump height

## Testing
- `npm run lint` *(fails: multiple lint errors in unrelated files)*
- `npm run type-check`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a158aed948323ae7f7091001c4bea