### PR TITLE
Fix challenge stats and add coin bonus

### DIFF
--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -8,6 +8,7 @@ import { CurrencyService } from '@/services/CurrencyService';
 import { ChallengeService } from '@/services/ChallengeService';
 import { AchievementService } from '@/services/AchievementService';
 import { UserService } from '@/services/UserServices';
+import { ECONOMY } from '@/lib/constants';
 import { GameCanvas } from './GameCanvas';
 import { GameCarousel } from './GameCarousel';
 import { CurrencyDisplay } from './CurrencyDisplay';
@@ -452,11 +453,28 @@ export function ArcadeHub() {
               {activeTab === 'challenges' && (
                 <>
                   <div className="lg:col-span-2">
-                    <DailyChallenges 
+                    <DailyChallenges
                       challengeService={challengeService}
                       onChallengeComplete={(challenge) => {
-                        addNotification('challenge', 'Challenge Complete!', `${challenge.title} - +${challenge.reward} coins`);
-                        currencyService.addCoins(challenge.reward, `challenge_${challenge.id}`);
+                        addNotification(
+                          'challenge',
+                          'Challenge Complete!',
+                          `${challenge.title} - +${challenge.reward} coins`
+                        );
+                        currencyService.addCoins(
+                          challenge.reward,
+                          `challenge_${challenge.id}`
+                        );
+                        const current = userService.getStats().challengesCompleted;
+                        userService.updateStats({ challengesCompleted: current + 1 });
+                        if (challengeService.areAllDailyChallengesCompleted()) {
+                          currencyService.setBonusMultiplier(ECONOMY.DAILY_CHALLENGE_MULTIPLIER);
+                          addNotification(
+                            'challenge',
+                            'All Daily Challenges Complete!',
+                            `Coins are now multiplied by ${ECONOMY.DAILY_CHALLENGE_MULTIPLIER}x`
+                          );
+                        }
                       }}
                     />
                   </div>
@@ -481,11 +499,28 @@ export function ArcadeHub() {
                 <>
                   <div className="lg:col-span-2">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      <DailyChallenges 
+                      <DailyChallenges
                         challengeService={challengeService}
                         onChallengeComplete={(challenge) => {
-                          addNotification('challenge', 'Challenge Complete!', `${challenge.title} - +${challenge.reward} coins`);
-                          currencyService.addCoins(challenge.reward, `challenge_${challenge.id}`);
+                          addNotification(
+                            'challenge',
+                            'Challenge Complete!',
+                            `${challenge.title} - +${challenge.reward} coins`
+                          );
+                          currencyService.addCoins(
+                            challenge.reward,
+                            `challenge_${challenge.id}`
+                          );
+                          const current = userService.getStats().challengesCompleted;
+                          userService.updateStats({ challengesCompleted: current + 1 });
+                          if (challengeService.areAllDailyChallengesCompleted()) {
+                            currencyService.setBonusMultiplier(ECONOMY.DAILY_CHALLENGE_MULTIPLIER);
+                            addNotification(
+                              'challenge',
+                              'All Daily Challenges Complete!',
+                              `Coins are now multiplied by ${ECONOMY.DAILY_CHALLENGE_MULTIPLIER}x`
+                            );
+                          }
                         }}
                       />
                       <AchievementPanel achievementService={achievementService} />

--- a/src/components/arcade/DailyChallenges.tsx
+++ b/src/components/arcade/DailyChallenges.tsx
@@ -14,18 +14,17 @@ export function DailyChallenges({ challengeService, onChallengeComplete }: Daily
 
   useEffect(() => {
     setChallenges(challengeService.getChallenges());
-    
     const unsubscribe = challengeService.onChallengesChanged((newChallenges) => {
       setChallenges(newChallenges);
-      
-      // Check for newly completed challenges
-      const completedChallenges = newChallenges.filter(c => c.completed);
-      completedChallenges.forEach(challenge => {
-        onChallengeComplete?.(challenge);
-      });
+    });
+    const unsubscribeComplete = challengeService.onChallengeCompleted((challenge) => {
+      onChallengeComplete?.(challenge);
     });
 
-    return unsubscribe;
+    return () => {
+      unsubscribe();
+      unsubscribeComplete();
+    };
   }, [challengeService, onChallengeComplete]);
 
   const dailyChallenges = challenges.filter(c => c.type === 'daily');

--- a/src/games/shared/BaseGame.ts
+++ b/src/games/shared/BaseGame.ts
@@ -83,9 +83,11 @@ export abstract class BaseGame implements GameModule {
 
   getScore(): GameScore {
     const timePlayedMs = this.isRunning ? Date.now() - this.startTime : this.gameTime;
+    const multiplier = this.services.currency.getBonusMultiplier?.() ?? 1;
     const coinsEarned = this.services.currency.calculateGameReward(
-      this.score, 
-      this.pickups
+      this.score,
+      this.pickups,
+      multiplier
     );
 
     return {

--- a/src/services/CurrencyService.ts
+++ b/src/services/CurrencyService.ts
@@ -11,6 +11,7 @@ export class CurrencyService {
   private currentCoins: number = 0;
   private transactions: CurrencyTransaction[] = [];
   private listeners: Array<(coins: number) => void> = [];
+  private bonusMultiplier: number = 1;
 
   init(): void {
     // Load from localStorage for now
@@ -22,6 +23,14 @@ export class CurrencyService {
 
   getCurrentCoins(): number {
     return this.currentCoins;
+  }
+
+  getBonusMultiplier(): number {
+    return this.bonusMultiplier;
+  }
+
+  setBonusMultiplier(multiplier: number): void {
+    this.bonusMultiplier = multiplier;
   }
 
   // Reset method for development
@@ -65,9 +74,10 @@ export class CurrencyService {
     return true;
   }
 
-  calculateGameReward(score: number, pickups: number, bonusMultiplier: number = 1): number {
-    const baseReward = Math.floor(score / ECONOMY.SCORE_TO_COINS_RATIO) + 
-                      (pickups * ECONOMY.PICKUP_COIN_VALUE);
+  calculateGameReward(score: number, pickups: number, bonusMultiplier: number = this.bonusMultiplier): number {
+    const baseReward =
+      Math.floor(score / ECONOMY.SCORE_TO_COINS_RATIO) +
+      pickups * ECONOMY.PICKUP_COIN_VALUE;
     return Math.floor(baseReward * bonusMultiplier);
   }
 


### PR DESCRIPTION
## Summary
- update `CurrencyService` with bonus multiplier support
- apply multiplier in `BaseGame`
- add completion events and helpers to `ChallengeService`
- update `DailyChallenges` to only fire completion callbacks once
- increment challenge stats and activate multiplier in `ArcadeHub`

## Testing
- `tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685b1d4e65c48323bbfcf50c338190ea