### PR TITLE
Fix parallax jitter and stabilize ground textures

### DIFF
--- a/src/games/runner/RunnerGame.ts
+++ b/src/games/runner/RunnerGame.ts
@@ -12,6 +12,10 @@ import { ComboSystem } from './systems/ComboSystem';
 import { EnvironmentSystem } from './systems/EnvironmentSystem';
 import { ParallaxSystem } from './systems/ParallaxSystem';
 
+// Deterministic noise function for ground textures
+const pseudoNoise = (x: number, y: number): number => {
+  return Math.abs(Math.sin(x * 12.9898 + y * 78.233)) % 1;
+};
 
 interface ActivePowerUp {
   type: PowerUpType;
@@ -76,6 +80,7 @@ export class RunnerGame extends BaseGame {
       this.canvas.height,
       this.groundY
     );
+    this.parallaxSystem.reset();
     this.startTime = Date.now();
     this.jumps = 0;
     this.powerupsUsed = 0;
@@ -105,12 +110,14 @@ export class RunnerGame extends BaseGame {
     this.handlePlayerEffects(jumpStarted);
     
     // Update game speed and distance
-    this.distance += this.gameSpeed * dt * 100;
+    const baseIncrement = this.gameSpeed * dt * 100;
+    this.distance += baseIncrement;
     this.gameSpeed = 1 + Math.floor(this.distance / 1000) * 0.2;
-    
+
     // Apply speed boost power-up
     const speedMultiplier = this.hasPowerUp('speed-boost') ? 1.5 : 1;
     const effectiveSpeed = this.gameSpeed * speedMultiplier;
+    const distanceIncrement = effectiveSpeed * dt * 100;
     
     // Update all entities
     this.updateEntities(dt, effectiveSpeed);
@@ -127,8 +134,8 @@ export class RunnerGame extends BaseGame {
     
     // Update score
     this.score = Math.floor(this.distance / 10);
-    // Update parallax system with current distance
-    this.parallaxSystem.update(this.distance);
+    // Scroll parallax layers by the distance moved this frame
+    this.parallaxSystem.update(distanceIncrement);
   }
 
   public getScore() {
@@ -378,13 +385,14 @@ export class RunnerGame extends BaseGame {
     ctx.fillStyle = grassGradient;
     ctx.fillRect(0, this.groundY - 8, this.canvas.width, 8);
     
-    // Add subtle ground texture
+    // Add subtle deterministic ground texture
     ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
     const textureOffset = (this.distance * 1.5) % 20;
     for (let x = -textureOffset; x < this.canvas.width; x += 20) {
       for (let y = this.groundY + 10; y < this.canvas.height; y += 15) {
-        if (Math.random() > 0.7) {
-          ctx.fillRect(x + Math.random() * 3, y, 1, 1);
+        const noise = pseudoNoise(x, y);
+        if (noise > 0.7) {
+          ctx.fillRect(x + (noise * 3) % 3, y, 1, 1);
         }
       }
     }
@@ -550,5 +558,6 @@ export class RunnerGame extends BaseGame {
     this.powerupsUsed = 0;
     this.powerupTypesUsed.clear();
     this.player = new Player(100, this.groundY - 32, this.groundY);
+    this.parallaxSystem.reset();
   }
 }

--- a/src/games/runner/systems/ParallaxSystem.ts
+++ b/src/games/runner/systems/ParallaxSystem.ts
@@ -64,8 +64,18 @@ export class ParallaxSystem {
     });
   }
   
-  update(distance: number): void {
-    this.distance = distance;
+  /**
+   * Advance the parallax layers by the given distance delta.
+   * Using a delta keeps the internal distance small and avoids
+   * precision issues when the game runs for a long time.
+   */
+  update(delta: number): void {
+    this.distance += delta;
+  }
+
+  /** Reset parallax scroll distance. */
+  reset(): void {
+    this.distance = 0;
   }
   
   render(ctx: CanvasRenderingContext2D, theme: EnvironmentTheme): void {


### PR DESCRIPTION
## Summary
- keep internal parallax distance and update using per-frame delta
- reset parallax system on init and restart
- use deterministic noise for ground texture to stop blinking

## Testing
- `npm install`
- `npm run lint` *(fails: react/no-unescaped-entities and many others)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1c24b2308323b85e5747e807d89b