### PR TITLE
Add instructions page and expand onboarding

### DIFF
--- a/src/app/instructions/page.tsx
+++ b/src/app/instructions/page.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'How to Play - HacktivateNations Arcade'
+};
+
+export default function InstructionsPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 p-4 text-gray-200">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <h1 className="text-3xl font-bold text-center text-white">How to Play</h1>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-bold text-purple-300">Getting Started</h2>
+          <p>
+            Play games to earn <span className="text-yellow-400 font-bold">coins</span>. Use coins to
+            unlock additional game tiers and customise your profile.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-bold text-purple-300">Game Tiers</h2>
+          <p>New games unlock as you progress through tiers:</p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Tier 0 – Runner game is available for free.</li>
+            <li>Tier 1 – Unlocks one extra game for 2,000 coins.</li>
+            <li>Tier 2 – Unlocks two more games for 5,000 coins.</li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-bold text-purple-300">Game Types</h2>
+          <p>The arcade features a variety of retro‑inspired games like Endless Runner and Block Puzzle. More games will be added over time.</p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-bold text-purple-300">Daily Challenges</h2>
+          <p>Every day you receive three random challenges. Complete them for bonus coins. Finishing all challenges applies a 1.5× coin multiplier.</p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-bold text-purple-300">Achievements</h2>
+          <p>Unlock one‑time achievements to earn extra coins and show off your skills.</p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-bold text-purple-300">Player Profile</h2>
+          <p>Your profile tracks level, play time, coins earned and more. Customise your avatar and view detailed stats in the Profile tab.</p>
+        </section>
+
+        <div className="text-center pt-4">
+          <Link href="/" className="arcade-button inline-block">Back to Arcade</Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/arcade/OnboardingOverlay.tsx
+++ b/src/components/arcade/OnboardingOverlay.tsx
@@ -7,12 +7,20 @@ interface OnboardingOverlayProps {
 export function OnboardingOverlay({ onClose }: OnboardingOverlayProps) {
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-75 flex items-center justify-center p-4">
-      <div className="bg-gray-900 p-6 rounded-lg max-w-sm text-center space-y-4">
+      <div className="bg-gray-900 p-6 rounded-lg max-w-sm text-center space-y-4 overflow-y-auto max-h-[80vh]">
         <h2 className="text-xl font-bold text-white">Welcome to HacktivateNations Arcade!</h2>
         <p className="text-gray-300 text-sm">
           Earn <span className="text-yellow-400 font-bold">coins</span> by playing games. Use them to unlock new tiers
           and track your progress in the <span className="font-bold">Profile</span> tab.
         </p>
+        <ul className="text-gray-300 text-sm text-left list-disc list-inside space-y-1">
+          <li>Tier 0 includes the Runner game for free.</li>
+          <li>Tier 1 (2,000 coins) and Tier 2 (5,000 coins) unlock more games.</li>
+          <li>Complete <span className="font-semibold">Daily Challenges</span> for bonus coins.</li>
+          <li>Earn <span className="font-semibold">Achievements</span> for one-time rewards.</li>
+          <li>Your <span className="font-semibold">Player Profile</span> tracks stats and levels.</li>
+        </ul>
+        <a href="/instructions" className="text-purple-300 underline text-sm hover:text-purple-200 block">View full instructions</a>
         <button onClick={onClose} className="arcade-button w-full text-sm">Got it!</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create `/instructions` route with gameplay overview
- enhance the onboarding overlay with tier, challenge and profile tips

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd633645c8323bf267fd6a0d7c607