### PR TITLE
Fix challenge completion stats

### DIFF
--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -52,7 +52,7 @@ export function ArcadeHub() {
     setCurrentCoins(currencyService.getCurrentCoins());
 
     let lastCoins = currencyService.getCurrentCoins();
-    const unsubscribe = currencyService.onCoinsChanged((newCoins) => {
+    const unsubscribeCoins = currencyService.onCoinsChanged((newCoins) => {
       const delta = newCoins - lastCoins;
       lastCoins = newCoins;
       setCurrentCoins(newCoins);
@@ -75,7 +75,12 @@ export function ArcadeHub() {
       });
     });
 
-    return unsubscribe;
+    const unsubscribeChallenges = challengeService.onChallengeCompleted(handleChallengeComplete);
+
+    return () => {
+      unsubscribeCoins();
+      unsubscribeChallenges();
+    };
   }, [challengeService, achievementService, userService]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure challenge completion updates user stats even when the DailyChallenges component is not mounted

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686092783e4c8323ba5a6f11008077bf