### PR TITLE
Fix challenge count in profile

### DIFF
--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -78,6 +78,7 @@ export function ArcadeHub() {
     return unsubscribe;
   }, [challengeService, achievementService, userService]);
 
+
   useEffect(() => {
     const seen = localStorage.getItem('hacktivate-onboarding-shown');
     if (!seen) {
@@ -191,6 +192,15 @@ export function ArcadeHub() {
     },
     [addNotification, currencyService, userService, challengeService]
   );
+
+  // Track completed challenges even when the DailyChallenges
+  // component isn't mounted by subscribing at the hub level.
+  useEffect(() => {
+    const unsubscribe = challengeService.onChallengeCompleted(
+      handleChallengeComplete
+    );
+    return unsubscribe;
+  }, [challengeService, handleChallengeComplete]);
 
   const handleGameEnd = (gameData?: any) => {
     if (!gameData || !selectedGameId) return;


### PR DESCRIPTION
## Summary
- update `ArcadeHub` to register the challenge completion listener at the hub level

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_686092783e4c8323ba5a6f11008077bf