### PR TITLE
Add shader background and smooth transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.19.2",
+        "glsl-canvas-js": "^0.2.9",
         "lucide-react": "^0.517.0",
         "next": "15.3.3",
         "react": "^19.0.0",
@@ -3496,6 +3498,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.19.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.2.tgz",
+      "integrity": "sha512-0cWMLkYr+i0emeXC4hkLF+5aYpzo32nRdQ0D/5DI460B3O7biQ3l2BpDzIGsAHYuZ0fpBP0DC8XBkVf6RPAlZw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.19.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3607,6 +3636,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.3.0.tgz",
+      "integrity": "sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==",
+      "license": "MIT"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3648,6 +3683,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glsl-canvas-js": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/glsl-canvas-js/-/glsl-canvas-js-0.2.9.tgz",
+      "integrity": "sha512-b26PXAU+nbAvu+JauFh8KQ8as/SAM/Aokad/Mb8phG2X8Ob1XTKlvFO/YUmgJbtmRPsLkIWmf3BjpGkIE3dJRw==",
+      "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "3.3.0",
+        "promise-polyfill": "8.2.0"
       }
     },
     "node_modules/gopd": {
@@ -4777,6 +4822,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
+      "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5245,6 +5305,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.19.2",
+    "glsl-canvas-js": "^0.2.9",
     "lucide-react": "^0.517.0",
     "next": "15.3.3",
     "react": "^19.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import { ShaderBackground } from '@/components/visuals/ShaderBackground';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -33,6 +34,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${inter.className} antialiased bg-gray-900 text-white custom-scrollbar`}>
+        <ShaderBackground />
         <div id="root">{children}</div>
       </body>
     </html>

--- a/src/components/arcade/ArcadeHub.tsx
+++ b/src/components/arcade/ArcadeHub.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { GameModule } from '@/lib/types';
 import { gameLoader } from '@/games/registry';
 import { CurrencyService } from '@/services/CurrencyService';
@@ -402,8 +403,16 @@ export function ArcadeHub() {
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto">
-        {showHub ? (
-          <div className="space-y-6">
+        <AnimatePresence mode="wait">
+          {showHub ? (
+            <motion.div
+              key="hub"
+              initial={{ opacity: 0, x: -30 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: 30 }}
+              transition={{ duration: 0.3 }}
+              className="space-y-6"
+            >
             {/* Tab Navigation */}
             <div className="flex justify-center">
               <div className="bg-gray-800 p-1 rounded-lg">
@@ -491,7 +500,7 @@ export function ArcadeHub() {
               <div className="text-center text-gray-300 mt-8">
                 <h3 className="text-xl mb-4">Welcome to the Arcade!</h3>
                 <p className="max-w-2xl mx-auto">
-                  Play games to earn coins and experience, unlock new games, complete daily challenges, 
+                  Play games to earn coins and experience, unlock new games, complete daily challenges,
                   and collect achievements. Each game offers unique challenges and rewards!
                 </p>
                 <p className="text-sm mt-4 opacity-75">
@@ -499,16 +508,24 @@ export function ArcadeHub() {
                 </p>
               </div>
             )}
-          </div>
-        ) : (
-          <div className="flex justify-center">
-            <GameCanvas 
-              game={currentGame} 
-              currencyService={currencyService}
-              onGameEnd={handleGameEnd}
-            />
-          </div>
-        )}
+            </motion.div>
+          ) : (
+            <motion.div
+              key="game"
+              initial={{ opacity: 0, x: 30 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -30 }}
+              transition={{ duration: 0.3 }}
+              className="flex justify-center"
+            >
+              <GameCanvas
+                game={currentGame}
+                currencyService={currencyService}
+                onGameEnd={handleGameEnd}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </main>
       {showOnboarding && (
         <OnboardingOverlay onClose={() => setShowOnboarding(false)} />

--- a/src/components/visuals/ShaderBackground.tsx
+++ b/src/components/visuals/ShaderBackground.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+import { GlslCanvas } from 'glsl-canvas-js';
+
+const fragShader = `
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform float u_time;
+uniform vec2 u_resolution;
+
+void main() {
+  vec2 st = gl_FragCoord.xy / u_resolution;
+  vec3 color = 0.5 + 0.5*cos(u_time + st.xyx + vec3(0.0,2.0,4.0));
+  gl_FragColor = vec4(color, 0.15);
+}
+`;
+
+export function ShaderBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const canvas = canvasRef.current;
+    const glsl = new GlslCanvas(canvas);
+    glsl.load(fragShader);
+
+    const handleResize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      glsl.setUniform('u_resolution', [canvas.width, canvas.height]);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    let frameId: number;
+    const animate = (t: number) => {
+      glsl.setUniform('u_time', t * 0.001);
+      frameId = requestAnimationFrame(animate);
+    };
+    frameId = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      glsl.destroy();
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="fixed inset-0 -z-10 pointer-events-none" />;
+}
+


### PR DESCRIPTION
## Summary
- add `framer-motion` and `glsl-canvas-js`
- create `ShaderBackground` for animated WebGL backdrop
- use shader background in the global layout
- add animated transitions when entering or leaving a game

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686070a4d100832393a1d5e061397f3f